### PR TITLE
Fix missing QProcess import

### DIFF
--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -5,7 +5,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout, QWidget, QSplitter, QPlainTextEdit, QPushButton, QToolBar,
     QDialog, QLabel, QFormLayout, QLineEdit, QDialogButtonBox
 )
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QProcess
 
 from ..models import Connection, Config
 from ..config import load_config, save_config


### PR DESCRIPTION
## Summary
- import `QProcess` from PyQt6

## Testing
- `pip install -r requirements.txt`
- `python3 -m sshmanager.main` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68547bda46e8832086b7f09a2ba5dac2