### PR TITLE
Fix lib path and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+sshmanager/libkonsole_embed.so
+__pycache__/
+sshmanager/__pycache__/
+sshmanager/ui/__pycache__/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python -m sshmanager.main
 ### Building the Konsole wrapper
 
 After installing the Qt and KF5 development packages, run the provided setup
-script to compile `libkonsole_embed.so`:
+script to compile `libkonsole_embed.so` inside the `sshmanager` package:
 
 ```bash
 ./setup.sh
@@ -42,7 +42,7 @@ The script simply runs the `g++` command shown below. You only need to run it
 once unless you modify `konsole_embed.cpp`.
 
 ```bash
-g++ -fPIC -shared konsole_embed.cpp -o libkonsole_embed.so \
+g++ -fPIC -shared konsole_embed.cpp -o sshmanager/libkonsole_embed.so \
   -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets \
   -I/usr/include/x86_64-linux-gnu/qt5/QtGui \
   -I/usr/include/x86_64-linux-gnu/qt5/QtCore \

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,8 @@ set -e
 
 # Compile the helper library used to embed Konsole via KParts.
 
-g++ -fPIC -shared konsole_embed.cpp -o libkonsole_embed.so \
+mkdir -p sshmanager
+g++ -fPIC -shared konsole_embed.cpp -o sshmanager/libkonsole_embed.so \
   -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets \
   -I/usr/include/x86_64-linux-gnu/qt5/QtGui \
   -I/usr/include/x86_64-linux-gnu/qt5/QtCore \


### PR DESCRIPTION
## Summary
- output library to `sshmanager/libkonsole_embed.so` for consistency with Python loader
- document new location in README
- ignore compiled library and caches

## Testing
- `bash setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685583af15b08320a266153265b41444