### PR TITLE
Fix Qt mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SSH Manager
 
-A simple graphical SSH connection manager built with PyQt6. This is a starting
+A simple graphical SSH connection manager built with PyQt5. This is a starting
 implementation based on the project description in `goal.txt`.
 
 ## Features
@@ -14,7 +14,7 @@ implementation based on the project description in `goal.txt`.
 ## Requirements
 
 - Python 3.10+
-- PyQt6
+- PyQt5
 - Qt5 development packages and `libkf5parts-dev` to build the Konsole wrapper
 
 Install Python dependencies with:

--- a/goal.txt
+++ b/goal.txt
@@ -80,7 +80,7 @@ Every connection can be edited using a modal dialog with the following fields:
 
 🛠️ Tech Stack
 Component	Tool/Library
-GUI	PyQt6 / PySide6
+GUI	PyQt5 / PySide6
 Terminal embed	KonsolePart (KDE terminal)
 SSH sessions	System ssh
 Config storage	JSON or SQLite (via GUI)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyQt6
+PyQt5

--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication
 import sys
 
 from .ui.main_window import MainWindow

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PyQt6.QtWidgets import (
+from PyQt5.QtWidgets import (
     QMainWindow,
     QTreeWidget,
     QTreeWidgetItem,
@@ -18,8 +18,8 @@ from PyQt6.QtWidgets import (
     QDialogButtonBox,
     QMenu,
 )
-from PyQt6.QtCore import Qt, QPoint
-from PyQt6.QtGui import QAction
+from PyQt5.QtCore import Qt, QPoint
+from PyQt5.QtWidgets import QAction
 
 from ..models import Connection, Config
 from ..config import load_config, save_config

--- a/sshmanager/util/konsole_embed.py
+++ b/sshmanager/util/konsole_embed.py
@@ -4,8 +4,8 @@ from ctypes import CDLL, c_void_p, c_char_p, c_int
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtWidgets import QWidget
-from PyQt6 import sip
+from PyQt5.QtWidgets import QWidget
+from PyQt5 import sip
 
 
 _lib: Optional[CDLL] = None


### PR DESCRIPTION
## Summary
- switch codebase to PyQt5 to match the Qt5 Konsole wrapper
- update requirements and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m sshmanager.main` *(fails: Could not load the Qt platform plugin "xcb")*

------
https://chatgpt.com/codex/tasks/task_e_6855865a84fc83209b941786108f2aab