### PR TITLE
Handle Ctrl+C and fix Konsole layout warning

### DIFF
--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -1,11 +1,13 @@
 from PyQt5.QtWidgets import QApplication
 import sys
+import signal
 
 from .ui.main_window import MainWindow
 
 
 def main() -> None:
     app = QApplication(sys.argv)
+    signal.signal(signal.SIGINT, lambda *args: app.quit())
     win = MainWindow()
     win.show()
     sys.exit(app.exec())

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -98,7 +98,7 @@ class TerminalTab(QWidget):
             port=connection.port,
             key=connection.key_path,
             initial_cmd=connection.initial_cmd,
-            parent=self,
+            parent=None,
         )
 
         if self.container is None:


### PR DESCRIPTION
## Summary
- remove parent argument when embedding Konsole to avoid duplicate layout warnings
- handle SIGINT so Ctrl+C cleanly exits the Qt app

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685588aae344832097f86067bae53557