### PR TITLE
Improve SIGINT handling

### DIFF
--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -1,4 +1,5 @@
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
 import sys
 import signal
 
@@ -8,6 +9,10 @@ from .ui.main_window import MainWindow
 def main() -> None:
     app = QApplication(sys.argv)
     signal.signal(signal.SIGINT, lambda *args: app.quit())
+    # Periodic no-op timer keeps the Qt event loop responsive to SIGINT
+    timer = QTimer()
+    timer.start(100)
+    timer.timeout.connect(lambda: None)
     win = MainWindow()
     win.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- make QApplication respond to Ctrl+C

## Testing
- `python3 -m sshmanager.main` *(fails: Could not load the Qt platform plugin "xcb" in "" even though it was found)*

------
https://chatgpt.com/codex/tasks/task_e_68558a06a4a0832080643c0b39d38b0d