### PR TITLE
Improve debugging messages

### DIFF
--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -2,12 +2,22 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QTimer
 import sys
 import signal
+import os
 
 from .ui.main_window import MainWindow
 
 
 def main() -> None:
-    app = QApplication(sys.argv)
+    args = sys.argv[:]
+    if "--debug" in args:
+        os.environ.setdefault("QT_DEBUG_PLUGINS", "1")
+        args.remove("--debug")
+        print("Debugging enabled (QT_DEBUG_PLUGINS=1)")
+
+    if not os.environ.get("DISPLAY"):
+        print("Warning: DISPLAY environment variable is not set. Qt may fail to start.")
+
+    app = QApplication(args)
     signal.signal(signal.SIGINT, lambda *args: app.quit())
     # Periodic no-op timer keeps the Qt event loop responsive to SIGINT
     timer = QTimer()

--- a/sshmanager/util/konsole_embed.py
+++ b/sshmanager/util/konsole_embed.py
@@ -11,11 +11,16 @@ from PyQt5 import sip
 _lib: Optional[CDLL] = None
 
 
-def _load_lib() -> CDLL:
+def _load_lib() -> Optional[CDLL]:
+    """Load the helper library, printing errors when it fails."""
     global _lib
     if _lib is None:
         lib_path = Path(__file__).resolve().parent.parent / "libkonsole_embed.so"
-        _lib = CDLL(str(lib_path))
+        try:
+            _lib = CDLL(str(lib_path))
+        except OSError as exc:
+            print(f"Failed to load {lib_path}: {exc}")
+            return None
         _lib.createKonsoleSshWidget.argtypes = [
             c_char_p,
             c_char_p,
@@ -38,6 +43,8 @@ def create_konsole_widget(
 ) -> Optional[QWidget]:
     """Create a Konsole widget running ssh via embedded KPart."""
     lib = _load_lib()
+    if lib is None:
+        return None
     parent_ptr = sip.unwrapinstance(parent) if parent else None
     ptr = lib.createKonsoleSshWidget(
         user.encode(),


### PR DESCRIPTION
## Summary
- handle failure to load `libkonsole_embed.so`
- add optional `--debug` argument and display checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68558b89bf588320872a147c878598c5