### PR TITLE
Fix disappearing Konsole tab

### DIFF
--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -98,7 +98,7 @@ class TerminalTab(QWidget):
             port=connection.port,
             key=connection.key_path,
             initial_cmd=connection.initial_cmd,
-            parent=None,
+            parent=self,
         )
 
         if self.container is None:


### PR DESCRIPTION
## Summary
- keep Konsole plugin alive by parenting it to the `TerminalTab`

## Testing
- `python -m py_compile sshmanager/ui/main_window.py`
- `pip install -r requirements.txt`
- `python -m sshmanager.main --debug` *(fails: cannot load Qt platform plugin "xcb")*

------
https://chatgpt.com/codex/tasks/task_e_685590ec9d3c83208fb7932d4d3104e2