### PR TITLE
Fix timer cleanup on terminal tabs

### DIFF
--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -140,6 +140,8 @@ class TerminalTab(QWidget):
             layout.addWidget(self.container)
 
     def closeEvent(self, event) -> None:
+        if hasattr(self, "_check_timer"):
+            self._check_timer.stop()
         super().closeEvent(event)
 
 


### PR DESCRIPTION
## Summary
- stop the periodic check timer when closing a terminal tab

## Testing
- `python -m py_compile sshmanager/ui/main_window.py`
- `python -m compileall -q sshmanager`


------
https://chatgpt.com/codex/tasks/task_e_6855a3c6686c8320aca2158927f2e7de