### PR TITLE
Add default shell tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ implementation based on the project description in `goal.txt`.
 
 - Sidebar showing folders and saved connections
 - Tabbed area for launching terminals embedded via KDE Konsole
+- Opens a local terminal tab at startup
 - Dialog for adding new connections
 - Context menu to edit or delete connections
 - Connections saved to `~/.sshmanager/connections.json`

--- a/sshmanager/util/konsole_embed.py
+++ b/sshmanager/util/konsole_embed.py
@@ -36,6 +36,8 @@ def _load_lib() -> Optional[CDLL]:
             c_void_p,
         ]
         _lib.createKonsoleSshWidget.restype = c_void_p
+        _lib.createKonsoleShellWidget.argtypes = [c_char_p, c_void_p]
+        _lib.createKonsoleShellWidget.restype = c_void_p
     return _lib
 
 
@@ -58,6 +60,27 @@ def create_konsole_widget(
         port,
         key.encode() if key else None,
         initial_cmd.encode() if initial_cmd else None,
+        parent_ptr,
+    )
+    if not ptr:
+        _last_error = (
+            "Could not start Konsole. Ensure the 'konsole' and 'konsole-kpart' packages are installed."
+        )
+        return None
+    return sip.wrapinstance(ptr, QWidget)
+
+
+def create_shell_widget(
+    shell: str | None = None,
+    parent: Optional[QWidget] = None,
+) -> Optional[QWidget]:
+    """Create a Konsole widget running a local shell."""
+    lib = _load_lib()
+    if lib is None:
+        return None
+    parent_ptr = sip.unwrapinstance(parent) if parent else None
+    ptr = lib.createKonsoleShellWidget(
+        shell.encode() if shell else None,
         parent_ptr,
     )
     if not ptr:


### PR DESCRIPTION
## Summary
- add new helper to embed plain Konsole shell
- expose create_shell_widget in Python wrapper
- show local terminal tab at startup
- document that a local terminal opens automatically

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855aa8d68e88320bdcc104f74796df4