### PR TITLE
Run ssh from Python shell widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,6 @@ g++ -fPIC -shared konsole_embed.cpp -o sshmanager/libkonsole_embed.so \
 ```
 
 This launches a window where you can add SSH connections. Double-click a
-connection to open a terminal tab. Each tab embeds the Konsole KPart running
-``ssh`` with your saved settings.
+connection to open a terminal tab. Each tab embeds the Konsole KPart. The
+application clears the terminal and sends the ``ssh`` command from Python,
+rather than launching it inside the C++ helper.

--- a/sshmanager/util/konsole_embed.py
+++ b/sshmanager/util/konsole_embed.py
@@ -38,6 +38,8 @@ def _load_lib() -> Optional[CDLL]:
         _lib.createKonsoleSshWidget.restype = c_void_p
         _lib.createKonsoleShellWidget.argtypes = [c_char_p, c_void_p]
         _lib.createKonsoleShellWidget.restype = c_void_p
+        _lib.sendInputToWidget.argtypes = [c_void_p, c_char_p]
+        _lib.sendInputToWidget.restype = None
     return _lib
 
 
@@ -89,6 +91,15 @@ def create_shell_widget(
         )
         return None
     return sip.wrapinstance(ptr, QWidget)
+
+
+def send_input(widget: QWidget, command: str) -> None:
+    """Send a command to the given Konsole widget."""
+    lib = _load_lib()
+    if lib is None:
+        return
+    widget_ptr = sip.unwrapinstance(widget)
+    lib.sendInputToWidget(widget_ptr, command.encode())
 
 
 def get_last_error() -> Optional[str]:


### PR DESCRIPTION
## Summary
- expose a new `sendInputToWidget` helper in C++
- load and wrap `sendInputToWidget` in `konsole_embed.py`
- open a shell widget for remote sessions and send the `ssh` command in Python
- update README to describe the new behavior

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `./setup.sh` *(fails: `fatal error: QWidget: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6855acfb76e0832088ac554ce5dd128f