### PR TITLE
Add movable and closable tabs

### DIFF
--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -163,6 +163,9 @@ class MainWindow(QMainWindow):
         self.tree = QTreeWidget(self)
         self.tree.setHeaderHidden(True)
         self.tab_widget = QTabWidget(self)
+        self.tab_widget.setTabsClosable(True)
+        self.tab_widget.setMovable(True)
+        self.tab_widget.tabCloseRequested.connect(self.close_tab)
 
         self.splitter.addWidget(self.tree)
         self.splitter.addWidget(self.tab_widget)
@@ -216,6 +219,14 @@ class MainWindow(QMainWindow):
             tab = TerminalTab(conn, self)
             self.tab_widget.addTab(tab, conn.label)
             self.tab_widget.setCurrentWidget(tab)
+
+    def close_tab(self, index: int) -> None:
+        """Close and delete the tab at the given index."""
+        widget = self.tab_widget.widget(index)
+        if widget is not None:
+            widget.close()
+            widget.deleteLater()
+        self.tab_widget.removeTab(index)
 
     def show_context_menu(self, pos: QPoint) -> None:
         item = self.tree.itemAt(pos)


### PR DESCRIPTION
## Summary
- make the tab widget movable and closable
- connect tab close request to new handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m sshmanager.main --help` *(fails: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_6855aeeea5f0832092695a39f1f16f6b