### PR TITLE
Add Ctrl+T shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ implementation based on the project description in `goal.txt`.
 - Dialog for adding new connections
 - Context menu to edit or delete connections
 - Connections saved to `~/.sshmanager/connections.json`
+- `Ctrl+T` opens a new empty terminal tab
 
 ## Requirements
 

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -190,6 +190,10 @@ class MainWindow(QMainWindow):
         prev_tab_shortcut = QShortcut(QKeySequence("Ctrl+Shift+Tab"), self)
         prev_tab_shortcut.activated.connect(self.prev_tab)
 
+        # Shortcut for opening a new local terminal tab
+        new_tab_shortcut = QShortcut(QKeySequence("Ctrl+T"), self)
+        new_tab_shortcut.activated.connect(self.open_shell_tab)
+
         self.load_connections()
         self.tree.itemDoubleClicked.connect(self.open_connection)
         self.tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)


### PR DESCRIPTION
## Summary
- add `Ctrl+T` shortcut to open a new local terminal tab
- document shortcut in README

## Testing
- `python -m compileall -q sshmanager`

------
https://chatgpt.com/codex/tasks/task_e_6855b1b81ec88320a46836d2cd4bc3de