### PR TITLE
Add Bitwarden config from notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ implementation based on the project description in `goal.txt`.
 - Context menu to edit or delete connections
 - Connections saved to `~/.sshmanager/connections.json`
 - `Ctrl+T` opens a new empty terminal tab
+- Bitwarden integration loads connection configs from Bitwarden items stored in
+  the `SSH` folder (requires the Bitwarden CLI)
 
 ## Requirements
 
@@ -58,3 +60,25 @@ This launches a window where you can add SSH connections. Double-click a
 connection to open a terminal tab. Each tab embeds the Konsole KPart. The
 application clears the terminal and sends the ``ssh`` command from Python,
 rather than launching it inside the C++ helper.
+
+### Bitwarden integration
+
+The [Bitwarden CLI](https://bitwarden.com/help/cli/) must be installed and you
+must be logged in (`bw login` and `bw unlock`). Connection information can be
+stored inside Bitwarden items placed in a folder named `SSH`. The item's
+**notes/description** field should contain JSON describing the connection, for
+example:
+
+```json
+{
+  "label": "Prod Server",
+  "host": "server.example.com",
+  "username": "alice",
+  "port": 22,
+  "key_path": "~/.ssh/id_rsa",
+  "initial_cmd": "uptime"
+}
+```
+
+When you enter the item name or ID in the connection dialog and click
+**Fetch**, these fields will be populated from the stored JSON.

--- a/goal.txt
+++ b/goal.txt
@@ -11,7 +11,8 @@ A fully GUI-configurable SSH Manager app built with Python and Qt, featuring:
 
     GUI dialogs for adding, editing, and deleting connections
 
-    Optional Bitwarden reference to fetch email + hostname (not credentials)
+    Bitwarden items in a folder named "SSH" store connection configs in the
+    description
 
 🖥️ Main UI Components
 🧭 Layout
@@ -36,7 +37,7 @@ Launch SSH in tabbed terminal	On click, opens in embedded Konsole tab
 Edit port forwarding	Visual interface for adding/removing rules
 Configure per-connection options	SSH user, port, key file, startup commands, etc.
 Collapse/expand sidebar	Like Kate/Dolphin
-Bitwarden fetch button (optional)	Fills email/host from matching Bitwarden item
+Bitwarden fetch button    Loads config JSON from matching Bitwarden item
 ⚙️ Connection Configuration (GUI-based)
 
 Every connection can be edited using a modal dialog with the following fields:
@@ -66,17 +67,13 @@ Every connection can be edited using a modal dialog with the following fields:
 
         Remote: 0.0.0.0:2222 → localhost:22
 
-🧩 Bitwarden Integration (Optional)
+🧩 Bitwarden Integration
 
     Manual entry of Bitwarden item name
 
     “🔄 Fetch from Bitwarden” button
 
-    Only fills:
-
-        email → used as SSH username
-
-        URI/name → used for hostname
+    Connection details stored as JSON in the item's description
 
 🛠️ Tech Stack
 Component	Tool/Library
@@ -92,7 +89,7 @@ App framework	Python 3.x
 
         Opens a form to enter host, user, key, port, etc.
 
-        Optional: enter Bitwarden item name → click "Fetch"
+        Enter Bitwarden item name → click "Fetch"
 
     Click “Save”
 

--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -1,0 +1,73 @@
+import json
+import logging
+import subprocess
+from shutil import which
+from typing import Any, Optional
+
+
+def is_available() -> bool:
+    """Return True if the Bitwarden CLI (`bw`) is available."""
+    return which("bw") is not None
+
+
+def _run_bw(args: list[str]) -> str:
+    """Run ``bw`` with the given arguments and return stdout."""
+    return subprocess.check_output(["bw", *args], text=True)
+
+
+def _get_ssh_folder_id() -> Optional[str]:
+    """Return the ID of the Bitwarden folder named ``SSH``."""
+    try:
+        output = _run_bw(["list", "folders"])
+        folders = json.loads(output)
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        logging.error("Failed to list Bitwarden folders: %s", exc)
+        return None
+    for folder in folders:
+        if folder.get("name") == "SSH":
+            return folder.get("id")
+    return None
+
+
+def fetch_credentials(item: str) -> Optional[dict[str, Any]]:
+    """Fetch connection config from a Bitwarden item located in ``SSH`` folder.
+
+    Parameters
+    ----------
+    item: str
+        The Bitwarden item ID or name to fetch via `bw get item`.
+
+    Returns
+    -------
+    Config dictionary parsed from the item's description, or ``None`` on
+    failure.
+    """
+    if not is_available():
+        logging.error("Bitwarden CLI not found in PATH")
+        return None
+    folder_id = _get_ssh_folder_id()
+    if folder_id is None:
+        logging.error("Bitwarden folder 'SSH' not found")
+        return None
+    try:
+        output = _run_bw(["get", "item", item])
+        data = json.loads(output)
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        logging.error("Failed to fetch Bitwarden item: %s", exc)
+        return None
+
+    if data.get("folderId") != folder_id:
+        logging.error("Item '%s' is not located in the 'SSH' folder", item)
+        return None
+
+    notes = data.get("notes") or data.get("notesPlain", "")
+    if not notes:
+        logging.error("Item '%s' has no description with config", item)
+        return None
+    try:
+        cfg = json.loads(notes)
+    except json.JSONDecodeError as exc:
+        logging.error("Config in Bitwarden notes is invalid JSON: %s", exc)
+        return None
+
+    return cfg


### PR DESCRIPTION
## Summary
- update README to describe storing JSON configs in Bitwarden
- clarify in goal.txt that the `SSH` folder holds Bitwarden configs
- fetch config from Bitwarden item notes and fill form fields

## Testing
- `python -m py_compile sshmanager/ui/main_window.py sshmanager/bitwarden.py`
- `pip install PyQt5`
- `python -m sshmanager.main --help` *(fails: Qt platform plugin "xcb" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b64a59988320bec5f37c42f7eb5f