### PR TITLE
Improve Bitwarden login UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ rather than launching it inside the C++ helper.
 ### Bitwarden integration
 
 The [Bitwarden CLI](https://bitwarden.com/help/cli/) must be installed and you
-must be logged in (`bw login` and `bw unlock`). Connection information can be
+must be logged in (`bw login` and `bw unlock`). The "Fetch" button in the
+connection dialog is disabled until the CLI reports the vault is unlocked.
+Connection information can be
 stored inside Bitwarden items placed in a folder named `SSH`. The item's
 **notes/description** field should contain JSON describing the connection, for
 example:

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QFormLayout,
     QLineEdit,
     QDialogButtonBox,
+    QMessageBox,
     QMenu,
     QShortcut,
     QHBoxLayout,
@@ -26,7 +27,11 @@ from PyQt5.QtWidgets import QAction
 
 from ..models import Connection, Config
 from ..config import load_config, save_config
-from ..bitwarden import fetch_credentials, is_available as bw_available
+from ..bitwarden import (
+    fetch_credentials,
+    is_available as bw_available,
+    is_unlocked as bw_unlocked,
+)
 
 
 class ConnectionDialog(QDialog):
@@ -53,7 +58,7 @@ class ConnectionDialog(QDialog):
         self.bw_item_edit = QLineEdit(self)
         self.fetch_btn = QPushButton("Fetch", self)
         self.fetch_btn.clicked.connect(self.fetch_from_bitwarden)
-        if not bw_available():
+        if not (bw_available() and bw_unlocked()):
             self.fetch_btn.setEnabled(False)
 
         if connection is not None:
@@ -110,6 +115,11 @@ class ConnectionDialog(QDialog):
             return
         cfg = fetch_credentials(item)
         if not cfg:
+            QMessageBox.warning(
+                self,
+                "Bitwarden",
+                "Failed to fetch item. Ensure you are logged in and unlocked.",
+            )
             return
         if cfg.get("label"):
             self.label_edit.setText(cfg["label"])


### PR DESCRIPTION
## Summary
- check Bitwarden status using `bw status`
- disable Bitwarden fetch until CLI is unlocked
- show a warning dialog when fetch fails
- document the new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855bb380a788320905f15442900e96e