### PR TITLE
Add email/password Bitwarden login

### DIFF
--- a/sshmanager/ui/login_dialog.py
+++ b/sshmanager/ui/login_dialog.py
@@ -11,15 +11,17 @@ class LoginDialog(QDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("Bitwarden API Login")
-        self.token_edit = QLineEdit(self)
-        self.token_edit.setEchoMode(QLineEdit.Password)
+        self.setWindowTitle("Bitwarden Login")
+        self.email_edit = QLineEdit(self)
+        self.password_edit = QLineEdit(self)
+        self.password_edit.setEchoMode(QLineEdit.Password)
         self.server_edit = QLineEdit(self)
         self.server_edit.setPlaceholderText("https://vault.bitwarden.com")
 
         layout = QFormLayout(self)
         layout.addRow("Server:", self.server_edit)
-        layout.addRow("API Token:", self.token_edit)
+        layout.addRow("Email:", self.email_edit)
+        layout.addRow("Master Password:", self.password_edit)
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
             parent=self,
@@ -30,4 +32,8 @@ class LoginDialog(QDialog):
 
     def values(self):
         server = self.server_edit.text().strip() or None
-        return self.token_edit.text().strip(), server
+        return (
+            self.email_edit.text().strip(),
+            self.password_edit.text(),
+            server,
+        )

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -206,15 +206,19 @@ class MainWindow(QMainWindow):
         menu.exec(self.tree.viewport().mapToGlobal(pos))
 
     def login_bitwarden(self) -> None:
-        """Prompt for an API token and reload connections."""
+        """Prompt for credentials and reload connections."""
         dlg = LoginDialog(self)
         if dlg.exec() != dlg.Accepted:
             return
-        token, server = dlg.values()
-        if not bitwarden.login(token, server):
-            QMessageBox.critical(self, "Login Failed", "Invalid Bitwarden token")
+        email, password, server = dlg.values()
+        if not bitwarden.login(email, password, server):
+            QMessageBox.critical(
+                self,
+                "Login Failed",
+                "Invalid Bitwarden credentials",
+            )
             return
-        self.statusBar().showMessage("Bitwarden token set", 3000)
+        self.statusBar().showMessage("Bitwarden login successful", 3000)
         self.config = load_config()
         self.load_connections()
 


### PR DESCRIPTION
## Summary
- update login dialog to accept email and master password
- implement Bitwarden login using credentials
- update main window to use new login routine

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c33f0d0083209efe13abfb3a75b2