### PR TITLE
Fix login workflow and dialog usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ rather than launching it inside the C++ helper.
 
 ### Bitwarden integration
 
-Click the **Login** button to provide a Bitwarden API token and optional server
-URL. The token can be generated in the web vault under Settings → API Key.
-After entering the token, connections are loaded from items placed in a folder
-named `SSH`. Only the item's login **username** and **URI** fields are used.
+Click the **Login** button and enter your Bitwarden email address and master
+password. An optional server URL can be provided if you're using a self-hosted
+Vaultwarden instance. Once authenticated, connections are loaded from items
+placed in a folder named `SSH`. Only the item's login **username** and **URI**
+fields are used.
 
 Each item name becomes the connection label. Only the URL and username are
 stored, and the default SSH port 22 is used.

--- a/sshmanager/ui/login_dialog.py
+++ b/sshmanager/ui/login_dialog.py
@@ -17,11 +17,12 @@ class LoginDialog(QDialog):
         self.password_edit.setEchoMode(QLineEdit.Password)
         self.server_edit = QLineEdit(self)
         self.server_edit.setPlaceholderText("https://vault.bitwarden.com")
+        self.email_edit.setFocus()
 
         layout = QFormLayout(self)
-        layout.addRow("Server:", self.server_edit)
         layout.addRow("Email:", self.email_edit)
         layout.addRow("Master Password:", self.password_edit)
+        layout.addRow("Server:", self.server_edit)
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
             parent=self,
@@ -29,6 +30,10 @@ class LoginDialog(QDialog):
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
         layout.addRow(self.buttons)
+
+        self.setTabOrder(self.email_edit, self.password_edit)
+        self.setTabOrder(self.password_edit, self.server_edit)
+        self.setTabOrder(self.server_edit, self.buttons)
 
     def values(self):
         server = self.server_edit.text().strip() or None


### PR DESCRIPTION
## Summary
- improve focus and tab order for the login dialog
- clarify login instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855c613dd4c8320920a9086c6f5f9e5