### PR TITLE
Improve Bitwarden login error reporting

### DIFF
--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -212,10 +212,11 @@ class MainWindow(QMainWindow):
             return
         email, password, server = dlg.values()
         if not bitwarden.login(email, password, server):
+            err = bitwarden.get_last_error() or "Invalid Bitwarden credentials"
             QMessageBox.critical(
                 self,
                 "Login Failed",
-                "Invalid Bitwarden credentials",
+                err,
             )
             return
         self.statusBar().showMessage("Bitwarden login successful", 3000)


### PR DESCRIPTION
## Summary
- remember the last login error when contacting Bitwarden
- show that login error in the UI instead of a generic message
- surface HTTP or network errors in the login dialog

## Testing
- `pip install -r requirements.txt`
- `python -m sshmanager.main --help` *(fails: Qt platform plugin "xcb" error)*
- `python - <<'PY'
import sshmanager.bitwarden as bw
bw.login('email','password')
print('err:', bw.get_last_error())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6855c7a1c8508320837dba0e70ddc5bd