### PR TITLE
Add toolbar profile menu

### DIFF
--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -187,3 +187,12 @@ def sync() -> Any:
     if not is_unlocked():
         return None
     return _run_bw(["sync"])
+
+
+def logout() -> None:
+    """Clear the current session and temporary config."""
+    global _session, _config_dir
+    _session = None
+    if _config_dir:
+        shutil.rmtree(_config_dir, ignore_errors=True)
+        _config_dir = None


### PR DESCRIPTION
## Summary
- add Bitwarden logout function
- show a profile menu in the toolbar
- disable the main UI when not logged in
- allow login and logout from the profile menu

## Testing
- `python -m py_compile sshmanager/**/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fa8921d88320bead7a19dc745523