### PR TITLE
Fix Bitwarden login to ignore existing session

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The application does not store your Bitwarden session. Only the email and
 server address are saved using the system keyring so the login dialog can be
 pre-filled on the next launch. The underlying ``bw`` CLI configuration is kept
 separate, so existing command line logins are unaffected.
+If a ``BW_SESSION`` environment variable is set from another ``bw``
+session, it is cleared during login so the application remains fully
+independent of any terminal usage.
 
 Each item name becomes the connection label. Only the URL and username are
 stored, and the default SSH port 22 is used.

--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -92,6 +92,7 @@ def login(
 
     _server = server or _DEFAULT_SERVER
     env = os.environ.copy()
+    env.pop("BW_SESSION", None)
     env["BW_SERVER"] = _server
     env["BW_CONFIGDIR"] = _config_dir
     try:


### PR DESCRIPTION
## Summary
- ensure any existing `BW_SESSION` env variable is cleared before calling `bw login`
- mention clearing of `BW_SESSION` in README

## Testing
- `python -m compileall sshmanager`

------
https://chatgpt.com/codex/tasks/task_e_6856fbced590832080ba1db73f16889d