### PR TITLE
Fix bw CLI isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ separate, so existing command line logins are unaffected.
 If a ``BW_SESSION`` environment variable is set from another ``bw``
 session, it is cleared during login so the application remains fully
 independent of any terminal usage.
+Any ``BW_CONFIG_DIR`` variable is also removed so the app uses an
+isolated temporary directory for its own ``bw`` configuration.
 
 Each item name becomes the connection label. Only the URL and username are
 stored, and the default SSH port 22 is used.

--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -40,10 +40,16 @@ def _run_bw(args: List[str], parse_json: bool = True) -> Any:
     env = os.environ.copy()
     if _server:
         env["BW_SERVER"] = _server
+    else:
+        env.pop("BW_SERVER", None)
     if _session:
         env["BW_SESSION"] = _session
+    else:
+        env.pop("BW_SESSION", None)
     if _config_dir:
-        env["BW_CONFIGDIR"] = _config_dir
+        env["BW_CONFIG_DIR"] = _config_dir
+    else:
+        env.pop("BW_CONFIG_DIR", None)
     try:
         result = subprocess.run(
             ["bw", *args],
@@ -93,8 +99,9 @@ def login(
     _server = server or _DEFAULT_SERVER
     env = os.environ.copy()
     env.pop("BW_SESSION", None)
+    env.pop("BW_CONFIG_DIR", None)
     env["BW_SERVER"] = _server
-    env["BW_CONFIGDIR"] = _config_dir
+    env["BW_CONFIG_DIR"] = _config_dir
     try:
         result = subprocess.run(
             ["bw", "login", email, password, "--raw"],


### PR DESCRIPTION
## Summary
- clean environment variables so `bw` CLI config and session don't leak in
- use the correct `BW_CONFIG_DIR` variable
- document the sanitized environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857005f65dc8320ae0b63e4688b20d0