### PR TITLE
Fix leftover bw CLI env vars

### DIFF
--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -97,9 +97,12 @@ def login(
         return False
 
     _server = server or _DEFAULT_SERVER
+    # Clear any bw CLI variables from our process environment so this session
+    # remains isolated from command line usage.
+    os.environ.pop("BW_SESSION", None)
+    os.environ.pop("BW_CONFIG_DIR", None)
+
     env = os.environ.copy()
-    env.pop("BW_SESSION", None)
-    env.pop("BW_CONFIG_DIR", None)
     env["BW_SERVER"] = _server
     env["BW_CONFIG_DIR"] = _config_dir
     try:
@@ -201,6 +204,8 @@ def logout() -> None:
     """Clear the current session and temporary config."""
     global _session, _config_dir
     _session = None
+    os.environ.pop("BW_SESSION", None)
+    os.environ.pop("BW_CONFIG_DIR", None)
     if _config_dir:
         shutil.rmtree(_config_dir, ignore_errors=True)
         _config_dir = None


### PR DESCRIPTION
## Summary
- ensure the bw session environment variables are removed from the SSH Manager process

## Testing
- `python -m py_compile sshmanager/bitwarden.py`

------
https://chatgpt.com/codex/tasks/task_e_68570859a88083208e7e26be773a35be