### PR TITLE
Improve Bitwarden CLI isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ server address are saved using the system keyring so the login dialog can be
 pre-filled on the next launch. The underlying ``bw`` CLI configuration is kept
 separate, so existing command line logins are unaffected.
 If a ``BW_SESSION`` environment variable is set from another ``bw``
-session, it is cleared during login so the application remains fully
-independent of any terminal usage.
-Any ``BW_CONFIG_DIR`` variable is also removed so the app uses an
-isolated temporary directory for its own ``bw`` configuration.
+session, it is ignored during login so the application remains fully
+independent of any terminal usage. Any ``BW_CONFIG_DIR`` variable is
+also ignored so the app uses an isolated temporary directory for its own
+``bw`` configuration.
 
 Each item name becomes the connection label. Only the URL and username are
 stored, and the default SSH port 22 is used.

--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -97,10 +97,9 @@ def login(
         return False
 
     _server = server or _DEFAULT_SERVER
-    # Clear any bw CLI variables from our process environment so this session
-    # remains isolated from command line usage.
-    os.environ.pop("BW_SESSION", None)
-    os.environ.pop("BW_CONFIG_DIR", None)
+    # Use a clean environment when invoking the CLI to avoid interfering with
+    # any active command line sessions, but do not modify this process
+    # environment so embedded terminals can continue using the user's session.
 
     env = os.environ.copy()
     env["BW_SERVER"] = _server
@@ -204,8 +203,6 @@ def logout() -> None:
     """Clear the current session and temporary config."""
     global _session, _config_dir
     _session = None
-    os.environ.pop("BW_SESSION", None)
-    os.environ.pop("BW_CONFIG_DIR", None)
     if _config_dir:
         shutil.rmtree(_config_dir, ignore_errors=True)
         _config_dir = None


### PR DESCRIPTION
## Summary
- keep existing `BW_SESSION` and `BW_CONFIG_DIR` env vars intact
- clarify README about ignoring bw cli env vars

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m sshmanager.main --help` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68570977d76883209de6b1a12a752fa3