### PR TITLE
Fix bw session isolation on login

### DIFF
--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -102,6 +102,9 @@ def login(
     # environment so embedded terminals can continue using the user's session.
 
     env = os.environ.copy()
+    # Ensure any existing session token from the user's shell is ignored so the
+    # application remains isolated from command line usage.
+    env.pop("BW_SESSION", None)
     env["BW_SERVER"] = _server
     env["BW_CONFIG_DIR"] = _config_dir
     try:


### PR DESCRIPTION
## Summary
- prevent `bw login` from inheriting external `BW_SESSION`

## Testing
- `python -m py_compile sshmanager/*.py sshmanager/ui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68572fd7306c8320af7d260514094a9a