### PR TITLE
Ensure Bitwarden env isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,8 @@ independent of any terminal usage. Any ``BW_CONFIG_DIR`` variable is
 also ignored so the app uses an isolated temporary directory for its own
 ``bw`` configuration.
 
+These variables are removed from the application's environment at startup so
+any embedded terminals do not inherit them.
+
 Each item name becomes the connection label. Only the URL and username are
 stored, and the default SSH port 22 is used.

--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -18,6 +18,11 @@ def main() -> None:
         format="%(asctime)s %(levelname)s: %(message)s",
     )
 
+    # Ensure any Bitwarden CLI environment from the launching shell does not
+    # leak into the application or embedded terminals.
+    os.environ.pop("BW_SESSION", None)
+    os.environ.pop("BW_CONFIG_DIR", None)
+
     def handle_exception(exc_type, exc_value, exc_traceback):
         if issubclass(exc_type, KeyboardInterrupt):
             sys.__excepthook__(exc_type, exc_value, exc_traceback)


### PR DESCRIPTION
## Summary
- remove `BW_SESSION` and `BW_CONFIG_DIR` from environment at startup
- document terminal environment cleanup in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685737e5f63083208221c86da35ce257