### PR TITLE
Fix environment separation from bw CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ pre-filled on the next launch. The underlying ``bw`` CLI configuration is kept
 separate, so existing command line logins are unaffected.
 If a ``BW_SESSION`` environment variable is set from another ``bw``
 session, it is ignored during login so the application remains fully
-independent of any terminal usage. Any ``BW_CONFIG_DIR`` variable is
+independent of any terminal usage. Any ``BW_APPDATA_DIR`` variable is
 also ignored so the app uses an isolated temporary directory for its own
 ``bw`` configuration.
 

--- a/sshmanager/bitwarden.py
+++ b/sshmanager/bitwarden.py
@@ -47,9 +47,9 @@ def _run_bw(args: List[str], parse_json: bool = True) -> Any:
     else:
         env.pop("BW_SESSION", None)
     if _config_dir:
-        env["BW_CONFIG_DIR"] = _config_dir
+        env["BW_APPDATA_DIR"] = _config_dir
     else:
-        env.pop("BW_CONFIG_DIR", None)
+        env.pop("BW_APPDATA_DIR", None)
     try:
         result = subprocess.run(
             ["bw", *args],
@@ -106,7 +106,7 @@ def login(
     # application remains isolated from command line usage.
     env.pop("BW_SESSION", None)
     env["BW_SERVER"] = _server
-    env["BW_CONFIG_DIR"] = _config_dir
+    env["BW_APPDATA_DIR"] = _config_dir
     try:
         result = subprocess.run(
             ["bw", "login", email, password, "--raw"],

--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -21,7 +21,7 @@ def main() -> None:
     # Ensure any Bitwarden CLI environment from the launching shell does not
     # leak into the application or embedded terminals.
     os.environ.pop("BW_SESSION", None)
-    os.environ.pop("BW_CONFIG_DIR", None)
+    os.environ.pop("BW_APPDATA_DIR", None)
 
     def handle_exception(exc_type, exc_value, exc_traceback):
         if issubclass(exc_type, KeyboardInterrupt):


### PR DESCRIPTION
## Summary
- correct the Bitwarden environment variable name for isolated CLI usage
- adjust startup cleanup accordingly
- update README docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 sshmanager | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_685739a9c7988320a370751024daf0ae