### PR TITLE
Fetch Bitwarden avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,5 @@ These variables are removed from the application's environment at startup so
 any embedded terminals do not inherit them.
 
 Each item name becomes the connection label. Only the URL and username are
-stored, and the default SSH port 22 is used.
+stored, and the default SSH port 22 is used. When logged in, the toolbar's
+profile button loads your Bitwarden avatar image if available.

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -17,9 +17,10 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QToolButton,
     QAction,
+    QSizePolicy,
 )
 from PyQt5.QtCore import Qt, QPoint, QTimer
-from PyQt5.QtGui import QKeySequence, QIcon
+from PyQt5.QtGui import QKeySequence, QIcon, QPixmap
 import keyring
 
 from ..models import Connection, Config
@@ -131,6 +132,10 @@ class MainWindow(QMainWindow):
         self.profile_menu = QMenu(self.profile_btn)
         self.profile_btn.setMenu(self.profile_menu)
         self.profile_btn.setPopupMode(QToolButton.InstantPopup)
+
+        spacer = QWidget(toolbar)
+        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        toolbar.addWidget(spacer)
         toolbar.addWidget(self.profile_btn)
 
         # Shortcuts for switching tabs
@@ -250,7 +255,17 @@ class MainWindow(QMainWindow):
             act = QAction("Logout", self)
             act.triggered.connect(self.logout_bitwarden)
             self.profile_menu.addAction(act)
+            avatar_data = bitwarden.fetch_avatar()
+            if avatar_data:
+                pix = QPixmap()
+                if pix.loadFromData(avatar_data):
+                    self.profile_btn.setIcon(QIcon(pix))
+                else:
+                    self.profile_btn.setIcon(QIcon.fromTheme("user-identity"))
+            else:
+                self.profile_btn.setIcon(QIcon.fromTheme("user-identity"))
         else:
             act = QAction("Login", self)
             act.triggered.connect(self.login_bitwarden)
             self.profile_menu.addAction(act)
+            self.profile_btn.setIcon(QIcon.fromTheme("user-identity"))


### PR DESCRIPTION
## Summary
- add helpers for retrieving Bitwarden user data
- download avatar image when logged in
- right-align profile button in toolbar and show avatar
- cache downloaded avatar data and reset it on login/logout
- document avatar support in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68598e864dd08320b1081daf40123996