### PR TITLE
Fix login name print placement

### DIFF
--- a/sshmanager/main.py
+++ b/sshmanager/main.py
@@ -17,7 +17,6 @@ def main() -> None:
         level=logging.DEBUG,
         format="%(asctime)s %(levelname)s: %(message)s",
     )
-    print("Name (email)")
 
     # Ensure any Bitwarden CLI environment from the launching shell does not
     # leak into the application or embedded terminals.

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -272,6 +272,11 @@ class MainWindow(QMainWindow):
         email, server = getattr(self, "_login_details", ("", ""))
         keyring.set_password("sshmanager", "email", email)
         keyring.set_password("sshmanager", "server", server or "")
+        info = bitwarden.user_info()
+        if info:
+            name = info.get("name", "")
+            email_addr = info.get("email", "")
+            print(f"{name} ({email_addr})")
         self.statusBar().showMessage("Bitwarden login successful", 3000)
         self.loading_dlg = LoadingDialog("Fetching data...", self)
         self.loading_dlg.show()


### PR DESCRIPTION
## Summary
- remove placeholder name/email print from app startup
- show actual user name and email after successful login

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859ab9215d4832090ea02acf66498bb