### PR TITLE
Add connection creation dialog and toolbar button

### DIFF
--- a/sshmanager/ui/__init__.py
+++ b/sshmanager/ui/__init__.py
@@ -1,4 +1,5 @@
 from .main_window import MainWindow
 from .login_dialog import LoginDialog
 from .loading_dialog import LoadingDialog
+from .connection_dialog import ConnectionDialog
 

--- a/sshmanager/ui/connection_dialog.py
+++ b/sshmanager/ui/connection_dialog.py
@@ -1,0 +1,73 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QLineEdit,
+    QFormLayout,
+)
+from PyQt5.QtGui import QIntValidator
+
+from ..models import Connection
+
+
+class ConnectionDialog(QDialog):
+    """Dialog to create or edit an SSH connection."""
+
+    def __init__(self, parent=None, connection: Connection | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("New Connection")
+        self._connection = connection
+
+        self.label_edit = QLineEdit(self)
+        self.host_edit = QLineEdit(self)
+        self.user_edit = QLineEdit(self)
+        self.port_edit = QLineEdit(self)
+        self.port_edit.setValidator(QIntValidator(1, 65535, self))
+        self.folder_edit = QLineEdit(self)
+        self.key_edit = QLineEdit(self)
+        self.initial_cmd_edit = QLineEdit(self)
+
+        if connection:
+            self.label_edit.setText(connection.label)
+            self.host_edit.setText(connection.host)
+            self.user_edit.setText(connection.username)
+            self.port_edit.setText(str(connection.port))
+            self.folder_edit.setText(connection.folder)
+            if connection.key_path:
+                self.key_edit.setText(connection.key_path)
+            if connection.initial_cmd:
+                self.initial_cmd_edit.setText(connection.initial_cmd)
+
+        layout = QFormLayout(self)
+        layout.addRow("Label:", self.label_edit)
+        layout.addRow("Host:", self.host_edit)
+        layout.addRow("Username:", self.user_edit)
+        layout.addRow("Port:", self.port_edit)
+        layout.addRow("Folder:", self.folder_edit)
+        layout.addRow("SSH Key Path:", self.key_edit)
+        layout.addRow("Initial Command:", self.initial_cmd_edit)
+
+        self.buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
+        )
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addRow(self.buttons)
+
+    def connection(self) -> Connection:
+        label = self.label_edit.text().strip()
+        host = self.host_edit.text().strip()
+        user = self.user_edit.text().strip()
+        port_text = self.port_edit.text().strip() or "22"
+        port = int(port_text)
+        folder = self.folder_edit.text().strip() or "Default"
+        key_path = self.key_edit.text().strip() or None
+        initial_cmd = self.initial_cmd_edit.text().strip() or None
+        return Connection(
+            label=label,
+            host=host,
+            username=user,
+            port=port,
+            folder=folder,
+            key_path=key_path,
+            initial_cmd=initial_cmd,
+        )

--- a/sshmanager/ui/main_window.py
+++ b/sshmanager/ui/main_window.py
@@ -28,6 +28,7 @@ from ..config import load_config
 from .. import bitwarden
 from .login_dialog import LoginDialog
 from .loading_dialog import LoadingDialog
+from .connection_dialog import ConnectionDialog
 
 
 class TerminalTab(QWidget):
@@ -157,6 +158,10 @@ class MainWindow(QMainWindow):
         toolbar = QToolBar("Main", self)
         self.addToolBar(toolbar)
 
+        self.new_conn_act = QAction(QIcon.fromTheme("list-add"), "New Connection", self)
+        self.new_conn_act.triggered.connect(self.create_connection)
+        toolbar.addAction(self.new_conn_act)
+
         self.profile_btn = QToolButton(self)
         self.profile_btn.setIcon(QIcon.fromTheme("user-identity"))
         self.profile_menu = QMenu(self.profile_btn)
@@ -203,6 +208,15 @@ class MainWindow(QMainWindow):
         tab = TerminalTab(None, self)
         self.tab_widget.addTab(tab, "Terminal")
         self.tab_widget.setCurrentWidget(tab)
+
+    def create_connection(self) -> None:
+        """Open a dialog to create a new connection and add it to the tree."""
+        dlg = ConnectionDialog(self)
+        if dlg.exec() != dlg.Accepted:
+            return
+        conn = dlg.connection()
+        self.config.connections.append(conn)
+        self.load_connections()
 
     def open_connection(self, item: QTreeWidgetItem):
         conn = item.data(0, Qt.ItemDataRole.UserRole)


### PR DESCRIPTION
## Summary
- add `ConnectionDialog` for configuring new connections
- export the dialog in `ui/__init__`
- add a toolbar action that opens the connection dialog and stores the new connection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af751940883209ec0e7025dd2cb1a