### PR TITLE
Fix loading spinner fallback

### DIFF
--- a/sshmanager/ui/loading_dialog.py
+++ b/sshmanager/ui/loading_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QProgressBar
 from PyQt5.QtGui import QMovie
 from PyQt5.QtCore import Qt
 
@@ -14,9 +14,14 @@ class LoadingDialog(QDialog):
         self.spinner_label = QLabel(self)
         self.spinner_label.setAlignment(Qt.AlignCenter)
         movie = QMovie(":/qt-project.org/styles/commonstyle/images/working-32.gif")
-        self.spinner_label.setMovie(movie)
-        movie.start()
-        layout.addWidget(self.spinner_label)
+        if movie.isValid():
+            self.spinner_label.setMovie(movie)
+            movie.start()
+            layout.addWidget(self.spinner_label)
+        else:
+            bar = QProgressBar(self)
+            bar.setRange(0, 0)
+            layout.addWidget(bar)
         text_label = QLabel(text, self)
         text_label.setAlignment(Qt.AlignCenter)
         layout.addWidget(text_label)


### PR DESCRIPTION
## Summary
- add missing fallback when spinner resource is unavailable

## Testing
- `python -m compileall -q sshmanager/ui/loading_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_685b0a5d7ac88320bec833ca5b6d6b4f